### PR TITLE
Access Modifiers can be modified for Generated Entities.

### DIFF
--- a/src/Kiota.Builder/CodeDOM/AccessModifier.cs
+++ b/src/Kiota.Builder/CodeDOM/AccessModifier.cs
@@ -2,6 +2,7 @@
 public enum AccessModifier
 {
     Public = 2,
+    Internal = 3,
     Protected = 1,
     Private = 0
 }

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -206,6 +206,7 @@ public class CodeClass : ProprietableBlock<CodeClassKind, ClassDeclaration>, ITy
         return AddRange(codeInterfaces);
     }
     public CodeClass? BaseClass => StartBlock.Inherits?.TypeDefinition as CodeClass;
+    public AccessModifier Access { get; set; } = AccessModifier.Public;
     /// <summary>
     /// The interface associated with this class, if any.
     /// </summary>

--- a/src/Kiota.Builder/CodeDOM/CodeEnum.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeEnum.cs
@@ -41,4 +41,5 @@ public class CodeEnum : CodeBlock<BlockDeclaration, BlockEnd>, IDocumentedElemen
     {
         get; set;
     }
+    public AccessModifier Access { get; set; } = AccessModifier.Public;
 }

--- a/src/Kiota.Builder/Configuration/GenerationConfiguration.cs
+++ b/src/Kiota.Builder/Configuration/GenerationConfiguration.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json.Nodes;
+using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 using Kiota.Builder.Lock;
 using Microsoft.OpenApi.ApiManifest;
@@ -39,6 +40,9 @@ public class GenerationConfiguration : ICloneable
     public string OutputPath { get; set; } = "./output";
     public string ClientClassName { get; set; } = "ApiClient";
     public string ClientNamespaceName { get; set; } = "ApiSdk";
+    public AccessModifier ApiClientAccessModifier { get; set; } = AccessModifier.Public;
+    public AccessModifier RequestBuilderAccessModifier { get; set; } = AccessModifier.Public;
+    public AccessModifier ModelsAccessModifier { get; set; } = AccessModifier.Public;
     public string NamespaceNameSeparator { get; set; } = ".";
     public bool ExportPublicApi
     {

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -258,6 +258,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                 {
                     DescriptionTemplate = "Instantiates a new {TypeName} and sets the default values.",
                 },
+                Access = currentClass.Access,
             });
         CrawlTree(current, x => AddConstructorsForDefaultValues(x, addIfInherited, forceAdd, classKindsToExclude));
     }
@@ -1423,8 +1424,8 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             foreach (var property in properties)
             {
                 property.ExistsInExternalBaseType = true;
-                if (accessModifier.HasValue)
-                    property.Access = accessModifier.Value;
+                // if (accessModifier.HasValue)
+                //     property.Access = accessModifier.Value;
             }
         }
 

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -96,6 +96,7 @@ public class CSharpConventionService : CommonLanguageConventionService
     {
         return access switch
         {
+            AccessModifier.Internal => "internal",
             AccessModifier.Public => "public",
             AccessModifier.Protected => "protected",
             _ => "private",

--- a/src/Kiota.Builder/Writers/CSharp/CodeClassDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeClassDeclarationWriter.cs
@@ -41,7 +41,7 @@ public class CodeClassDeclarationWriter : BaseElementWriter<ClassDeclaration, CS
         conventions.WriteDeprecationAttribute(parentClass, writer);
         writer.WriteLine(GeneratedCodeAttribute);
         if (!hasDescription) conventions.WritePragmaDisable(writer, CSharpConventionService.CS1591);
-        writer.WriteLine($"public partial class {codeElement.Name.ToFirstCharacterUpperCase()} {derivation}");
+        writer.WriteLine($"{conventions.GetAccessModifier(parentClass.Access)} partial class {codeElement.Name.ToFirstCharacterUpperCase()} {derivation}");
         if (!hasDescription) conventions.WritePragmaRestore(writer, CSharpConventionService.CS1591);
         writer.StartBlock();
     }

--- a/src/Kiota.Builder/Writers/CSharp/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeEnumWriter.cs
@@ -37,7 +37,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, CSharpConventionServic
             writer.WriteLine("[Flags]");
         conventions.WriteDeprecationAttribute(codeElement, writer);
         if (!hasDescription) writer.WriteLine("#pragma warning disable CS1591");
-        writer.WriteLine($"public enum {codeElement.Name.ToFirstCharacterUpperCase()}");
+        writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} enum {codeElement.Name.ToFirstCharacterUpperCase()}");
         if (!hasDescription) writer.WriteLine("#pragma warning restore CS1591");
         writer.StartBlock();
         var idx = 0;

--- a/src/Kiota.Builder/Writers/CSharp/CodeIndexerWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeIndexerWriter.cs
@@ -16,7 +16,7 @@ public class CodeIndexerWriter : BaseElementWriter<CodeIndexer, CSharpConvention
         conventions.WriteShortDescription(codeElement.IndexParameter, writer, $"<param name=\"position\">", "</param>");
         conventions.WriteAdditionalDescriptionItem($"<returns>A {conventions.GetTypeStringForDocumentation(codeElement.ReturnType, codeElement)}</returns>", writer);
         conventions.WriteDeprecationAttribute(codeElement, writer);
-        writer.WriteLine($"public {returnType} this[{conventions.GetTypeString(codeElement.IndexParameter.Type, codeElement)} position]");
+        writer.WriteLine($"{conventions.GetAccessModifier(parentClass.Access)} {returnType} this[{conventions.GetTypeString(codeElement.IndexParameter.Type, codeElement)} position]");
         writer.StartBlock();
         writer.WriteLine("get");
         writer.StartBlock();

--- a/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
@@ -60,9 +60,9 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, CSharpConventi
                 break;
             case CodePropertyKind.ErrorMessageOverride when parentClass.IsErrorDefinition:
                 if (parentClass.GetPrimaryMessageCodePath(static x => x.Name.ToFirstCharacterUpperCase(), static x => x.Name.ToFirstCharacterUpperCase(), "?.") is string primaryMessageCodePath && !string.IsNullOrEmpty(primaryMessageCodePath))
-                    writer.WriteLine($"public override {propertyType} {codeElement.Name.ToFirstCharacterUpperCase()} {{ get => {primaryMessageCodePath} ?? string.Empty; }}");
+                    writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} override {propertyType} {codeElement.Name.ToFirstCharacterUpperCase()} {{ get => {primaryMessageCodePath} ?? string.Empty; }}");
                 else
-                    writer.WriteLine($"public override {propertyType} {codeElement.Name.ToFirstCharacterUpperCase()} {{ get => base.Message; }}");
+                    writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} override {propertyType} {codeElement.Name.ToFirstCharacterUpperCase()} {{ get => base.Message; }}");
                 break;
             case CodePropertyKind.QueryParameter when codeElement.IsNameEscaped:
                 writer.WriteLine($"[QueryParameter(\"{codeElement.SerializationName}\")]");

--- a/src/kiota/Handlers/KiotaGenerateCommandHandler.cs
+++ b/src/kiota/Handlers/KiotaGenerateCommandHandler.cs
@@ -3,6 +3,7 @@ using System.CommandLine.Invocation;
 using System.Text.Json;
 
 using Kiota.Builder;
+using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 
 using Microsoft.Extensions.Logging;
@@ -28,6 +29,18 @@ internal class KiotaGenerateCommandHandler : BaseKiotaCommandHandler
         get; init;
     }
     public required Option<string> NamespaceOption
+    {
+        get; init;
+    }
+    public required Option<AccessModifier> ApiClientAccessModifierOption
+    {
+        get; init;
+    }
+    public required Option<AccessModifier> RequestBuilderAccessModifierOption
+    {
+        get; init;
+    }
+    public required Option<AccessModifier> ModelsAccessModifierOption
     {
         get; init;
     }
@@ -73,6 +86,9 @@ internal class KiotaGenerateCommandHandler : BaseKiotaCommandHandler
         bool includeAdditionalData = context.ParseResult.GetValueForOption(AdditionalDataOption);
         string className = context.ParseResult.GetValueForOption(ClassOption) ?? string.Empty;
         string namespaceName = context.ParseResult.GetValueForOption(NamespaceOption) ?? string.Empty;
+        AccessModifier apiClientAccessModifier = context.ParseResult.GetValueForOption(ApiClientAccessModifierOption);
+        AccessModifier requestBuilderAccessModifier = context.ParseResult.GetValueForOption(RequestBuilderAccessModifierOption);
+        AccessModifier modelsAccessModifier = context.ParseResult.GetValueForOption(ModelsAccessModifierOption);
         List<string> serializer = context.ParseResult.GetValueForOption(SerializerOption) ?? [];
         List<string> deserializer = context.ParseResult.GetValueForOption(DeserializerOption) ?? [];
         List<string> includePatterns = context.ParseResult.GetValueForOption(IncludePatternsOption) ?? [];
@@ -86,6 +102,9 @@ internal class KiotaGenerateCommandHandler : BaseKiotaCommandHandler
         AssignIfNotNullOrEmpty(manifest, (c, s) => c.ApiManifestPath = s);
         AssignIfNotNullOrEmpty(className, (c, s) => c.ClientClassName = s);
         AssignIfNotNullOrEmpty(namespaceName, (c, s) => c.ClientNamespaceName = s);
+        Configuration.Generation.ApiClientAccessModifier = apiClientAccessModifier;
+        Configuration.Generation.RequestBuilderAccessModifier = requestBuilderAccessModifier;
+        Configuration.Generation.ModelsAccessModifier = modelsAccessModifier;
         Configuration.Generation.UsesBackingStore = backingStore;
         Configuration.Generation.ExcludeBackwardCompatible = excludeBackwardCompatible;
         Configuration.Generation.IncludeAdditionalData = includeAdditionalData;

--- a/src/kiota/KiotaHost.cs
+++ b/src/kiota/KiotaHost.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using kiota.Handlers;
 using kiota.Rpc;
 using Kiota.Builder;
+using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Configuration;
 using Kiota.Builder.Validation;
 using Microsoft.Extensions.Logging;
@@ -349,6 +350,12 @@ public static partial class KiotaHost
         AddEnumValidator(languageOption, "language");
         return languageOption;
     }
+    internal static Option<AccessModifier> GetAccessModifierOption(string argumentHelpName, string type, AccessModifier defaultAccessModifier)
+    {
+        var accessModifierOption = new Option<AccessModifier>($"--{argumentHelpName}", () => defaultAccessModifier, $"The access modifier option for the generated {type}.");
+        AddEnumValidator(accessModifierOption, argumentHelpName);
+        return accessModifierOption;
+    }
     internal static Option<string> GetNamespaceOption(string defaultNamespaceName)
     {
         var namespaceOption = new Option<string>("--namespace-name", () => defaultNamespaceName, "The namespace to use for the core client class specified with the --class-name option.");
@@ -419,6 +426,12 @@ public static partial class KiotaHost
 
         var namespaceOption = GetNamespaceOption(defaultConfiguration.ClientNamespaceName);
 
+        var apiClientAccessModifierOption = GetAccessModifierOption("api-client-accessibility-modifier", "ApiClient", defaultConfiguration.ApiClientAccessModifier);
+
+        var requestBuilderAccessModifierOption = GetAccessModifierOption("request-builder-accessibility-modifier", "RequestBuilder", defaultConfiguration.RequestBuilderAccessModifier);
+
+        var modelsAccessModifierOption = GetAccessModifierOption("models-accessibility-modifier", "Model", defaultConfiguration.ModelsAccessModifier);
+
         var logLevelOption = GetLogLevelOption();
 
         var backingStoreOption = GetBackingStoreOption(defaultConfiguration.UsesBackingStore);
@@ -460,6 +473,9 @@ public static partial class KiotaHost
             languageOption,
             classOption,
             namespaceOption,
+            apiClientAccessModifierOption,
+            requestBuilderAccessModifierOption,
+            modelsAccessModifierOption,
             logLevelOption,
             backingStoreOption,
             excludeBackwardCompatible,
@@ -482,6 +498,9 @@ public static partial class KiotaHost
             LanguageOption = languageOption,
             ClassOption = classOption,
             NamespaceOption = namespaceOption,
+            ApiClientAccessModifierOption = apiClientAccessModifierOption,
+            RequestBuilderAccessModifierOption = requestBuilderAccessModifierOption,
+            ModelsAccessModifierOption = modelsAccessModifierOption,
             LogLevelOption = logLevelOption,
             BackingStoreOption = backingStoreOption,
             ExcludeBackwardCompatibleOption = excludeBackwardCompatible,

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -5256,7 +5256,256 @@ components:
         Assert.NotNull(responseProperty);
         Assert.Equal("some path item description", responseProperty.Documentation.DescriptionTemplate);
     }
+    [Theory]
+    [InlineData(true, AccessModifier.Private)]
+    [InlineData(true, AccessModifier.Public)]
+    [InlineData(true, AccessModifier.Protected)]
+    [InlineData(true, AccessModifier.Internal)]
+    [InlineData(false, AccessModifier.Public)]
+    public void AccessModifierShouldBeConfigurableForApiClientClassNodes(bool applyAccessModifierToConfig, AccessModifier expectedAccessModifier)
+    {
+        var config = new GenerationConfiguration();
+        if (applyAccessModifierToConfig)
+        {
+            config.ApiClientAccessModifier = expectedAccessModifier;
+        }
 
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, config, _httpClient);
+        var document = new OpenApiDocument();
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+
+        var clientNamespace = codeModel.FindNamespaceByName(config.ClientNamespaceName);
+        Assert.NotNull(clientNamespace);
+
+        var foundClass = clientNamespace.FindChildByName<CodeClass>(config.ClientClassName, false);
+        Assert.NotNull(foundClass);
+        Assert.Equal(expectedAccessModifier, foundClass.Access);
+    }
+    [Theory]
+    [InlineData(true, AccessModifier.Private)]
+    [InlineData(true, AccessModifier.Public)]
+    [InlineData(true, AccessModifier.Protected)]
+    [InlineData(true, AccessModifier.Internal)]
+    [InlineData(false, AccessModifier.Public)]
+    public void AccessModifierShouldBeConfigurableForRequestBuilderClassNodes(bool applyAccessModifierToConfig, AccessModifier expectedAccessModifier)
+    {
+        var config = new GenerationConfiguration();
+        if (applyAccessModifierToConfig)
+        {
+            config.RequestBuilderAccessModifier = expectedAccessModifier;
+        }
+
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, config, _httpClient);
+        var document = AccessModifierOpenApiDocumentSample();
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+
+        var pathNamespace = codeModel.FindNamespaceByName($"{config.ClientNamespaceName}.SamplePath");
+        Assert.NotNull(pathNamespace);
+
+        var foundCodeClass = pathNamespace.FindChildByName<CodeClass>("SamplePathRequestBuilder", false);
+        Assert.NotNull(foundCodeClass);
+        Assert.Equal(expectedAccessModifier, foundCodeClass.Access);
+    }
+    [Theory]
+    [InlineData(true, AccessModifier.Private)]
+    [InlineData(true, AccessModifier.Public)]
+    [InlineData(true, AccessModifier.Protected)]
+    [InlineData(true, AccessModifier.Internal)]
+    [InlineData(false, AccessModifier.Public)]
+    public void AccessModifierShouldBeConfigurableForRequestConfigurationClassNodes(bool applyAccessModifierToConfig, AccessModifier expectedAccessModifier)
+    {
+        var config = new GenerationConfiguration();
+        if (applyAccessModifierToConfig)
+        {
+            config.RequestBuilderAccessModifier = expectedAccessModifier;
+        }
+
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, config, _httpClient);
+        var document = AccessModifierOpenApiDocumentSample();
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+
+        var pathNamespace = codeModel.FindNamespaceByName($"{config.ClientNamespaceName}.SamplePath");
+        Assert.NotNull(pathNamespace);
+
+        var foundCodeClass = pathNamespace.FindChildByName<CodeClass>("SamplePathRequestBuilder", false);
+        Assert.NotNull(foundCodeClass);
+
+        var foundChildCodeClass = foundCodeClass.FindChildByName<CodeClass>("SamplePathRequestBuilderGetRequestConfiguration");
+        Assert.Equal(expectedAccessModifier, foundChildCodeClass.Access);
+    }
+    [Theory]
+    [InlineData(true, AccessModifier.Private)]
+    [InlineData(true, AccessModifier.Public)]
+    [InlineData(true, AccessModifier.Protected)]
+    [InlineData(true, AccessModifier.Internal)]
+    [InlineData(false, AccessModifier.Public)]
+    public void AccessModifierShouldBeConfigurableForQueryParameterClassNodes(bool applyAccessModifierToConfig, AccessModifier expectedAccessModifier)
+    {
+        var config = new GenerationConfiguration();
+        if (applyAccessModifierToConfig)
+        {
+            config.RequestBuilderAccessModifier = expectedAccessModifier;
+        }
+
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, config, _httpClient);
+        var document = AccessModifierOpenApiDocumentSample();
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+
+        var pathNamespace = codeModel.FindNamespaceByName($"{config.ClientNamespaceName}.SamplePath");
+        Assert.NotNull(pathNamespace);
+
+        var foundCodeClass = pathNamespace.FindChildByName<CodeClass>("SamplePathRequestBuilder", false);
+        Assert.NotNull(foundCodeClass);
+
+        var foundChildCodeClass = foundCodeClass.FindChildByName<CodeClass>("SamplePathRequestBuilderGetQueryParameters");
+        Assert.Equal(expectedAccessModifier, foundChildCodeClass.Access);
+    }
+    [Theory]
+    [InlineData(true, AccessModifier.Private)]
+    [InlineData(true, AccessModifier.Public)]
+    [InlineData(true, AccessModifier.Protected)]
+    [InlineData(true, AccessModifier.Internal)]
+    [InlineData(false, AccessModifier.Public)]
+    public void AccessModifierShouldBeConfigurableForModelClassNodes(bool applyAccessModifierToConfig, AccessModifier expectedAccessModifier)
+    {
+        var config = new GenerationConfiguration();
+        if (applyAccessModifierToConfig)
+        {
+            config.ModelsAccessModifier = expectedAccessModifier;
+        }
+
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, config, _httpClient);
+        var document = AccessModifierOpenApiDocumentSample();
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+
+        var modelsNamespaceNode = codeModel.FindNamespaceByName(config.ModelsNamespaceName);
+        Assert.NotNull(modelsNamespaceNode);
+
+        var foundCodeClass = modelsNamespaceNode.FindChildByName<CodeClass>("ExampleSchema", false);
+        Assert.NotNull(foundCodeClass);
+        Assert.Equal(expectedAccessModifier, foundCodeClass.Access);
+    }
+    [Theory]
+    [InlineData(true, AccessModifier.Private)]
+    [InlineData(true, AccessModifier.Public)]
+    [InlineData(true, AccessModifier.Protected)]
+    [InlineData(true, AccessModifier.Internal)]
+    [InlineData(false, AccessModifier.Public)]
+    public void AccessModifierShouldBeConfigurableForModelEnumNodes(bool applyAccessModifierToConfig, AccessModifier expectedAccessModifier)
+    {
+        var config = new GenerationConfiguration();
+        if (applyAccessModifierToConfig)
+        {
+            config.ModelsAccessModifier = expectedAccessModifier;
+        }
+
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, config, _httpClient);
+        var document = AccessModifierOpenApiDocumentSample();
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+
+        var modelsNamespaceNode = codeModel.FindNamespaceByName(config.ModelsNamespaceName);
+        Assert.NotNull(modelsNamespaceNode);
+
+        var foundCodeEnum = modelsNamespaceNode.FindChildByName<CodeEnum>("ExampleSchema_choices", false);
+        Assert.NotNull(foundCodeEnum);
+        Assert.Equal(expectedAccessModifier, foundCodeEnum.Access);
+    }
+    private OpenApiDocument AccessModifierOpenApiDocumentSample()
+    {
+        var exampleSchema = new OpenApiSchema
+        {
+            Type = "object",
+            Properties = new Dictionary<string, OpenApiSchema>
+            {
+                {
+                    "choices", new OpenApiSchema
+                    {
+                        Type = "string",
+                        Enum = new List<IOpenApiAny>
+                        {
+                            new OpenApiString("choice1"),
+                            new OpenApiString("choice2"),
+                        }
+                    }
+                }
+            },
+            Reference = new OpenApiReference
+            {
+                Id = "ExampleSchema",
+                Type = ReferenceType.Schema
+            },
+            UnresolvedReference = false
+        };
+        return new OpenApiDocument
+        {
+            Components = new OpenApiComponents
+            {
+                Schemas =
+                {
+                    ["ExampleSchema"] = exampleSchema
+                }
+            },
+            Paths = new OpenApiPaths
+            {
+                ["SamplePath"] = new OpenApiPathItem
+                {
+                    Operations = {
+                        [OperationType.Get] = new OpenApiOperation
+                        {
+                            Parameters = new List<OpenApiParameter>()
+                            {
+                                new OpenApiParameter
+                                {
+                                    Name = "TestQueryParameter",
+                                    In = ParameterLocation.Query,
+                                    Schema = new OpenApiSchema {
+                                        Type = "string",
+                                    }
+                                }
+                            },
+                            Responses = new OpenApiResponses
+                            {
+                                ["200"] = new OpenApiResponse {
+                                    Content = {
+                                        ["application/json"] = new OpenApiMediaType {
+                                            Schema = new OpenApiSchema {
+                                                Properties = new Dictionary<string, OpenApiSchema> {
+                                                    {
+                                                        "name", new OpenApiSchema {
+                                                            Type = "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                ["500"] = new OpenApiResponse {
+                                    Content = {
+                                        ["application/json"] = new OpenApiMediaType {
+                                            Schema = exampleSchema,
+                                        }
+                                    }
+                                },
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
     [Fact]
     public void Considers200WithSchemaOver2XXWithSchema()
     {

--- a/tests/Kiota.Tests/KiotaHostTests.cs
+++ b/tests/Kiota.Tests/KiotaHostTests.cs
@@ -58,6 +58,21 @@ public sealed class KiotaHostTests : IDisposable
         Assert.Equal(1, await KiotaHost.GetRootCommand().InvokeAsync(["generate", "-c", ".Graph"], _console));
     }
     [Fact]
+    public async Task ThrowsOnInvalidApiClientAccessibilityModifierAsync()
+    {
+        Assert.Equal(1, await KiotaHost.GetRootCommand().InvokeAsync(["generate", "--api-client-accessibility-modifier", "InvalidAccessModifier"], _console));
+    }
+    [Fact]
+    public async Task ThrowsOnInvalidRequestBuilderAccessibilityModifierAsync()
+    {
+        Assert.Equal(1, await KiotaHost.GetRootCommand().InvokeAsync(["generate", "--request-builder-accessibility-modifier", "InvalidAccessModifier"], _console));
+    }
+    [Fact]
+    public async Task ThrowsOnInvalidModlesAccessibilityModifierAsync()
+    {
+        Assert.Equal(1, await KiotaHost.GetRootCommand().InvokeAsync(["generate", "-=models-accessibility-modifier", "InvalidAccessModifier"], _console));
+    }
+    [Fact]
     public async Task AcceptsDeserializersAsync()
     {
         Assert.Equal(1, await KiotaHost.GetRootCommand().InvokeAsync(["generate", "--ds", "Kiota.Tests.TestData.TestDeserializer"], _console));


### PR DESCRIPTION
CLI Options have been added which map to generated CodeNode/CodeEnum as below.

api-client-accessibility-modifier
- The API Client.

request-builder-accessibility-modifier:
- CodeClassKind.RequestBuilder,
- CodeClassKind.QueryParameters,
- CodeClassKind.RequestConfiguration.

models-accessibility-modifier:
- CodeClassKind.Model.

"Internal" Access Modifier has been added.